### PR TITLE
Fix conflicting /events routes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1112,11 +1112,12 @@ def export_endabrechnung_jahr_pdf():
     response.headers['Content-Type'] = 'application/pdf'
     response.headers['Content-Disposition'] = 'inline; filename=endabrechnung_pro_jahr.pdf'
     return response
-@app.route("/events")
+@app.route("/events/list")
 def event_list():
     events = Event.query.order_by(Event.datum.desc()).all()  # ⬅ lädt alle Events
     return render_template("event_list.html", events=events)  # ⬅ übergibt sie an das Template
-@app.route("/events")
+
+@app.route("/events/dashboard")
 def events_dashboard():
     return render_template("events.html")
 @app.route("/event/start", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- resolve duplicate `/events` path by creating distinct URLs
- new routes `/events/list` and `/events/dashboard`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from app import create_app
app = create_app()
client = app.test_client()
for path in ["/events/list", "/events/dashboard"]:
    resp = client.get(path)
    print(path, resp.status_code)
print('index', client.get('/').status_code)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68577ae7aafc8327a5d4b3236ed673ab

## Zusammenfassung von Sourcery

Fehlerbehebungen:
- Behebt den doppelten `/events` Pfad durch Erstellung von unterschiedlichen Routen `/events/list` und `/events/dashboard`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve duplicate `/events` path by creating distinct `/events/list` and `/events/dashboard` routes.

</details>