### PR TITLE
Use env var for Flask secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Kassensystem
+
+This application uses Flask with SQLAlchemy.
+
+## Configuration
+
+Set the environment variable `SECRET_KEY` to configure the Flask secret key. If the variable is not provided, the app defaults to `change-me`.

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ import os
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 # Flask-Konfiguration
-SECRET_KEY = "super-secret-key"
+# SECRET_KEY kann per Umgebungsvariable gesetzt werden
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")
 SQLALCHEMY_DATABASE_URI = f"sqlite:///{os.path.join(BASE_DIR, 'instance/kassensystem.sqlite')}"
 SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
## Summary
- read secret key from environment in `config.py`
- document the new `SECRET_KEY` environment variable in a README

## Testing
- `python -m py_compile config.py app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68577b9c52248327a667ce2464f0cd3d

## Zusammenfassung von Sourcery

Erlaube die Konfiguration des Flask SECRET_KEY über eine Umgebungsvariable mit einem Fallback-Standardwert und dokumentiere die Konfiguration

Neue Funktionen:
- Liest den Flask SECRET_KEY aus der Umgebungsvariable SECRET_KEY

Verbesserungen:
- Verwende einen Standardwert, wenn die Umgebungsvariable nicht gesetzt ist

Dokumentation:
- Füge einen README-Abschnitt hinzu, der die Umgebungsvariable SECRET_KEY und ihren Standardwert beschreibt

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow configuring Flask SECRET_KEY via environment variable with a fallback default and document the configuration

New Features:
- Read the Flask SECRET_KEY from the SECRET_KEY environment variable

Enhancements:
- Use a default value when the environment variable is not set

Documentation:
- Add README section describing the SECRET_KEY environment variable and its default value

</details>