### PR TITLE
Enable editing participants inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ Settings are loaded from `config.py`. The following environment variable is supp
 
 - Python 3.11+
 - Flask 2.3.3
+
+## Features
+
+- Manage events, drinks and participants
+- Add new participants and edit existing names directly on the creation page

--- a/app/routes.py
+++ b/app/routes.py
@@ -64,7 +64,10 @@ def edit_teilnehmer(teilnehmer_id):
     if request.method == "POST":
         teilnehmer.name = request.form["name"]
         db.session.commit()
-        return redirect(url_for("index"))
+        next_url = request.form.get("next") or request.args.get("next")
+        if not next_url:
+            next_url = url_for("index")
+        return redirect(next_url)
 
     return render_template("teilnehmer_edit.html", teilnehmer=teilnehmer)
 @app.route("/getraenk", methods=["GET", "POST"])

--- a/app/templates/teilnehmer_create.html
+++ b/app/templates/teilnehmer_create.html
@@ -24,9 +24,15 @@
     {% if teilnehmer_liste %}
     <div class="mt-10 bg-white text-gray-900 rounded-lg shadow p-6">
         <h2 class="text-xl font-semibold mb-4">Bereits erfasste Teilnehmer</h2>
-        <ul class="list-disc list-inside space-y-1">
+        <ul class="space-y-2">
             {% for teilnehmer in teilnehmer_liste %}
-                <li>{{ teilnehmer.name }}</li>
+                <li>
+                    <form action="{{ url_for('edit_teilnehmer', teilnehmer_id=teilnehmer.id) }}" method="POST" class="flex items-center space-x-2">
+                        <input type="text" name="name" value="{{ teilnehmer.name }}" class="flex-1 px-2 py-1 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        <input type="hidden" name="next" value="{{ url_for('create_teilnehmer') }}">
+                        <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700">Speichern</button>
+                    </form>
+                </li>
             {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
## Summary
- allow editing of participant names directly on the creation page
- redirect back to the participant page after saving
- document the feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586b0331c48327b3d5e0164a84b41c

## Zusammenfassung von Sourcery

Ermöglicht die Inline-Bearbeitung von Teilnehmernamen auf der Erstellungsseite mit einer Rückleitung zur Ursprungsseite und aktualisiert die Dokumentation, um diese neue Funktion widerzuspiegeln.

Neue Funktionen:
- Inline-Bearbeitung von Teilnehmernamen auf der Teilnehmererstellungsseite ermöglichen.
- Nach dem Speichern der Teilnehmeränderungen zurück zur Originalseite leiten.

Verbesserungen:
- Unterstützung eines `next`-Parameters in der Bearbeitungsroute, um das Weiterleitungsziel nach dem Speichern zu bestimmen.

Dokumentation:
- Dokumentation der Inline-Bearbeitung und der Weiterleitungsfunktion in der README unter Funktionen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable inline editing of participant names on the creation page with a return redirect to the originating page, and update documentation to reflect this new feature.

New Features:
- Allow editing participant names inline on the participant creation page.
- Redirect back to the original page after saving participant edits.

Enhancements:
- Support a `next` parameter in the edit route to determine the redirect destination after saving.

Documentation:
- Document the inline editing and redirection feature in the README under Features.

</details>