### PR TITLE
Add overview and export options

### DIFF
--- a/app/templates/auswertungen_overview.html
+++ b/app/templates/auswertungen_overview.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Auswertungen</title>
+</head>
+<body>
+    <h1>Auswertungen</h1>
+
+    <h2>Teilnehmerbezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('teilnehmer_report') }}">Teilnehmerreport</a></li>
+        <li><a href="{{ url_for('verbrauch_pro_teilnehmer') }}">Verbrauch pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('teilnehmerliste') }}">Teilnehmerliste</a></li>
+        <li><a href="{{ url_for('teilnehmerliste_pro_event') }}">Teilnehmerliste pro Event</a></li>
+    </ul>
+
+    <h2>Eventbezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('event_uebersicht') }}">Eventübersicht pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('einzelabrechnung_event') }}">Einzelabrechnung pro Event</a></li>
+        <li><a href="{{ url_for('endabrechnung_event') }}">Endabrechnung pro Event</a></li>
+    </ul>
+
+    <h2>Zeit- und Jahresbezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('umsatzverlauf') }}">Umsatzverlauf</a></li>
+        <li><a href="{{ url_for('umsatz_pro_jahr') }}">Umsatz pro Jahr</a></li>
+        <li><a href="{{ url_for('endabrechnung_jahr') }}">Endabrechnung pro Jahr</a></li>
+    </ul>
+
+    <h2>Getränkebezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('getraenkestatistik') }}">Getränkestatistik</a></li>
+    </ul>
+
+    <h2>Finanzübersicht</h2>
+    <ul>
+        <li><a href="{{ url_for('umsatz_pro_teilnehmer') }}">Umsatz pro Teilnehmer</a></li>
+    </ul>
+
+    <br><a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+</body>
+</html>

--- a/app/templates/einzelabrechnung_event.html
+++ b/app/templates/einzelabrechnung_event.html
@@ -5,6 +5,7 @@
     <title>Einzelabrechnung pro Teilnehmer</title>
 </head>
 {% if selected_event_id %}
+    <a href="{{ url_for('export_einzelabrechnung_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
     <a href="{{ url_for('einzelabrechnung_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export</a>
 {% endif %}
 <body>

--- a/app/templates/endabrechnung_event.html
+++ b/app/templates/endabrechnung_event.html
@@ -53,9 +53,8 @@
         <p><strong>{{ "Gewinn" if daten.gewinn >= 0 else "Verlust" }}:</strong> {{ "%.2f"|format(daten.gewinn) }} CHF</p>
 
         <br>
-        <a href="{{ url_for('export_endabrechnung_event_pdf', event_id=selected_event_id) }}" target="_blank">
-            📄 PDF-Export der Endabrechnung
-        </a>
+        <a href="{{ url_for('export_endabrechnung_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_endabrechnung_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export der Endabrechnung</a>
     {% endif %}
 
     <br><br>

--- a/app/templates/endabrechnung_jahr.html
+++ b/app/templates/endabrechnung_jahr.html
@@ -7,9 +7,8 @@
 <body>
     <h1>Endabrechnung pro Jahr</h1>
 
-    <a href="{{ url_for('export_endabrechnung_jahr_pdf') }}" target="_blank">
-        📄 PDF-Export der Jahresendabrechnung
-    </a>
+    <a href="{{ url_for('export_endabrechnung_jahr_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_endabrechnung_jahr_pdf') }}" target="_blank">📄 PDF-Export der Jahresendabrechnung</a>
 
     <br><br>
 

--- a/app/templates/event_uebersicht.html
+++ b/app/templates/event_uebersicht.html
@@ -21,7 +21,8 @@
 
     {% if selected_event_id %}
         <p>
-            📥 <a href="{{ url_for('export_csv', event_id=selected_event_id) }}">Teilnehmer-Export (CSV)</a><br>
+            📥 <a href="{{ url_for('export_csv', event_id=selected_event_id) }}">Teilnehmer-Export (CSV)</a> |
+            📄 <a href="{{ url_for('export_event_uebersicht_pdf', event_id=selected_event_id) }}" target="_blank">PDF</a>
         </p>
     {% endif %}
 

--- a/app/templates/event_uebersicht_pdf.html
+++ b/app/templates/event_uebersicht_pdf.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        h1, h2 { margin-bottom: 0; }
+        table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+        th, td { border: 1px solid #444; padding: 5px; }
+        th { background-color: #eee; }
+        hr { margin: 20px 0; }
+    </style>
+    <title>Eventübersicht</title>
+</head>
+<body>
+    <h1>Eventübersicht – {{ event.name }}</h1>
+    <p>Datum: {{ event.datum.strftime('%d.%m.%Y') }}</p>
+    {% for eintrag in daten %}
+        <h2>{{ eintrag.teilnehmer }} (Status: {{ eintrag.status }})</h2>
+        <table>
+            <tr>
+                <th>Getränk</th>
+                <th>Anzahl</th>
+                <th>Betrag</th>
+            </tr>
+            {% for getraenk, menge, betrag in eintrag.buchungen %}
+            <tr>
+                <td>{{ getraenk }}</td>
+                <td>{{ menge }}</td>
+                <td>{{ "%.2f"|format(betrag or 0) }} CHF</td>
+            </tr>
+            {% endfor %}
+            <tr>
+                <td colspan="2"><strong>Gesamt</strong></td>
+                <td><strong>{{ "%.2f"|format(eintrag.gesamt) }} CHF</strong></td>
+            </tr>
+        </table>
+        <hr>
+    {% endfor %}
+</body>
+</html>

--- a/app/templates/getraenkestatistik.html
+++ b/app/templates/getraenkestatistik.html
@@ -22,7 +22,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_getraenkestatistik_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_getraenkestatistik_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_getraenkestatistik_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,7 +37,7 @@
             </a>
 
             <!-- Auswertungen -->
-            <a href="{{ url_for('teilnehmer_report') }}" class="bg-white text-gray-900 rounded-xl p-6 shadow hover:bg-blue-100 transition">
+            <a href="{{ url_for('auswertungen_overview') }}" class="bg-white text-gray-900 rounded-xl p-6 shadow hover:bg-blue-100 transition">
                 <div class="text-xl font-semibold mb-1">📊 Auswertungen</div>
                 <p class="text-sm text-gray-600">Verbrauch & Abrechnung ansehen</p>
             </a>

--- a/app/templates/teilnehmer_report.html
+++ b/app/templates/teilnehmer_report.html
@@ -6,6 +6,10 @@
 </head>
 <body>
     <h1>Teilnehmerauswertung über mehrere Events</h1>
+    <p>
+        <a href="{{ url_for('teilnehmer_report_export') }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('teilnehmer_report_pdf') }}" target="_blank">📄 PDF-Export</a>
+    </p>
 
     {% if daten %}
         {% for eintrag in daten %}

--- a/app/templates/teilnehmerliste.html
+++ b/app/templates/teilnehmerliste.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_teilnehmerliste_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_teilnehmerliste_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_teilnehmerliste_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/teilnehmerliste_event.html
+++ b/app/templates/teilnehmerliste_event.html
@@ -32,7 +32,8 @@
             {% endfor %}
         </table>
         <br>
-        <a href="{{ url_for('export_teilnehmerliste_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a>
+        <a href="{{ url_for('export_teilnehmerliste_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_teilnehmerliste_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export</a>
     {% endif %}
 
     <br><br>

--- a/app/templates/umsatz_jahr.html
+++ b/app/templates/umsatz_jahr.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_umsatz_pro_jahr_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_umsatz_pro_jahr_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_umsatz_pro_jahr_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/umsatz_teilnehmer.html
+++ b/app/templates/umsatz_teilnehmer.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_umsatz_pro_teilnehmer_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_umsatz_pro_teilnehmer_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_umsatz_pro_teilnehmer_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/umsatzverlauf.html
+++ b/app/templates/umsatzverlauf.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_umsatzverlauf_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_umsatzverlauf_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_umsatzverlauf_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/umsatzverlauf_pdf.html
+++ b/app/templates/umsatzverlauf_pdf.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+        th, td { border: 1px solid #444; padding: 5px; }
+        th { background-color: #eee; }
+    </style>
+    <title>Umsatzverlauf</title>
+</head>
+<body>
+    <h1>Umsatzverlauf (täglich)</h1>
+    <table>
+        <tr><th>Datum</th><th>Umsatz (CHF)</th></tr>
+        {% for datum, betrag in daten %}
+        <tr><td>{{ datum }}</td><td>{{ "%.2f"|format(betrag or 0) }}</td></tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/app/templates/verbrauch_teilnehmer.html
+++ b/app/templates/verbrauch_teilnehmer.html
@@ -6,6 +6,10 @@
 </head>
 <body>
     <h1>Verbrauch pro Teilnehmer</h1>
+    <p>
+        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_csv') }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_pdf') }}" target="_blank">📄 PDF-Export</a>
+    </p>
 
     {% for eintrag in daten %}
         <h2>{{ eintrag.teilnehmer }}</h2>


### PR DESCRIPTION
## Summary
- add a new `/auswertungen` overview
- link to overview from the start page
- support PDF export for event overview and sales history
- provide CSV export for several reports
- show CSV/PDF links on every analysis page

## Testing
- `python -m py_compile app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68586e9bf4948327ba660ae6cdb6026f