### PR TITLE
Add comparison and finance reports

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -157,6 +157,42 @@ def export_csv():
         headers={"Content-Disposition": f"attachment; filename=event_{event_id}_teilnehmer.csv"}
     )
 
+@app.route("/uebersicht/export_pdf")
+def export_event_uebersicht_pdf():
+    event_id = request.args.get("event_id", type=int)
+    if not event_id:
+        return redirect(url_for("event_uebersicht"))
+
+    event = Event.query.get_or_404(event_id)
+    daten = []
+    teilnehmer_events = TeilnehmerEvent.query.filter_by(event_id=event_id).all()
+    for te in teilnehmer_events:
+        buchungen = (
+            db.session.query(Getraenk.name, func.count(Verkauf.id), func.sum(Getraenk.preis))
+            .join(Verkauf, Verkauf.getraenk_id == Getraenk.id)
+            .filter(Verkauf.teilnehmer_event_id == te.id)
+            .group_by(Getraenk.name)
+            .all()
+        )
+        daten.append({
+            "teilnehmer": te.teilnehmer.name,
+            "buchungen": buchungen,
+            "gesamt": sum(row[2] or 0 for row in buchungen),
+            "status": te.bezahlt_status
+        })
+
+    html = render_template("event_uebersicht_pdf.html", event=event, daten=daten)
+
+    pdf_puffer = io.BytesIO()
+    pisa_status = pisa.CreatePDF(src=html, dest=pdf_puffer)
+    if pisa_status.err:
+        return f"Fehler beim Erstellen des PDFs: {pisa_status.err}"
+
+    response = make_response(pdf_puffer.getvalue())
+    response.headers['Content-Type'] = 'application/pdf'
+    response.headers['Content-Disposition'] = f'inline; filename=event_{event_id}_uebersicht.pdf'
+    return response
+
 @app.route("/export/umsatz")
 def export_umsatz():
     output = io.StringIO()
@@ -188,6 +224,11 @@ def export_umsatz():
         mimetype="text/csv",
         headers={"Content-Disposition": "attachment; filename=umsatzuebersicht.csv"}
     )
+
+@app.route("/auswertungen")
+def auswertungen_overview():
+    """Übersichtsseite für alle Auswertungen."""
+    return render_template("auswertungen_overview.html")
 @app.route("/zahlung", methods=["GET", "POST"])
 def zahlung_verwalten():
     events = Event.query.order_by(Event.datum.desc()).all()
@@ -441,6 +482,56 @@ def verbrauch_pro_teilnehmer():
         })
 
     return render_template("verbrauch_teilnehmer.html", daten=daten)
+
+@app.route("/auswertung/verbrauch_pro_teilnehmer/export_csv")
+def export_verbrauch_pro_teilnehmer_csv():
+    teilnehmer_liste = Teilnehmer.query.order_by(Teilnehmer.name).all()
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Teilnehmer", "Kategorie", "Bezeichnung", "Betrag CHF"])
+
+    for t in teilnehmer_liste:
+        gesamt = (
+            db.session.query(func.sum(Getraenk.preis))
+            .join(Verkauf, Verkauf.getraenk_id == Getraenk.id)
+            .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .filter(TeilnehmerEvent.teilnehmer_id == t.id)
+            .scalar() or 0.0
+        )
+        writer.writerow([t.name, "Gesamt", "", f"{gesamt:.2f}"])
+
+        jahre = (
+            db.session.query(func.strftime('%Y', Verkauf.zeitpunkt), func.sum(Getraenk.preis))
+            .join(Getraenk, Verkauf.getraenk_id == Getraenk.id)
+            .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .filter(TeilnehmerEvent.teilnehmer_id == t.id)
+            .group_by(func.strftime('%Y', Verkauf.zeitpunkt))
+            .order_by(func.strftime('%Y', Verkauf.zeitpunkt))
+            .all()
+        )
+        for jahr, betrag in jahre:
+            writer.writerow([t.name, "Jahr", jahr, f"{betrag:.2f}"])
+
+        events = (
+            db.session.query(Event.name, func.sum(Getraenk.preis))
+            .join(TeilnehmerEvent, TeilnehmerEvent.event_id == Event.id)
+            .join(Verkauf, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .join(Getraenk, Verkauf.getraenk_id == Getraenk.id)
+            .filter(TeilnehmerEvent.teilnehmer_id == t.id)
+            .group_by(Event.name)
+            .order_by(Event.datum)
+            .all()
+        )
+        for eventname, betrag in events:
+            writer.writerow([t.name, "Event", eventname, f"{betrag:.2f}"])
+
+    output.seek(0)
+    return Response(
+        output,
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=verbrauch_pro_teilnehmer.csv"}
+    )
 @app.route("/auswertung/teilnehmerliste")
 def teilnehmerliste():
     daten = (
@@ -547,6 +638,37 @@ def einzelabrechnung_event():
             })
 
     return render_template("einzelabrechnung_event.html", events=events, daten=daten, selected_event_id=selected_event_id)
+
+@app.route("/auswertung/einzelabrechnung_event/export_csv")
+def export_einzelabrechnung_event_csv():
+    event_id = request.args.get("event_id", type=int)
+    if not event_id:
+        return redirect(url_for("einzelabrechnung_event"))
+
+    teilnehmer_events = TeilnehmerEvent.query.filter_by(event_id=event_id).all()
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Teilnehmer", "Getränk", "Anzahl", "Einzelpreis", "Summe", "Status"])
+
+    for te in teilnehmer_events:
+        buchungen = (
+            db.session.query(Getraenk.name, func.count(Verkauf.id), Getraenk.preis, func.sum(Getraenk.preis))
+            .join(Verkauf, Verkauf.getraenk_id == Getraenk.id)
+            .filter(Verkauf.teilnehmer_event_id == te.id)
+            .group_by(Getraenk.name)
+            .all()
+        )
+        for name, menge, preis, betrag in buchungen:
+            writer.writerow([te.teilnehmer.name, name, menge, f"{preis:.2f}", f"{betrag:.2f}", te.bezahlt_status])
+        gesamt = sum(row[3] or 0 for row in buchungen)
+        writer.writerow([te.teilnehmer.name, "Gesamt", "", "", f"{gesamt:.2f}", te.bezahlt_status])
+
+    output.seek(0)
+    return Response(
+        output,
+        mimetype="text/csv",
+        headers={"Content-Disposition": f"attachment; filename=einzelabrechnung_event_{event_id}.csv"}
+    )
 @app.route("/auswertung/umsatzverlauf")
 def umsatzverlauf():
     daten = (
@@ -581,6 +703,27 @@ def export_umsatzverlauf_csv():
         mimetype="text/csv",
         headers={"Content-Disposition": "attachment; filename=umsatzverlauf.csv"}
     )
+
+@app.route("/auswertung/umsatzverlauf/pdf")
+def export_umsatzverlauf_pdf():
+    daten = (
+        db.session.query(func.date(Verkauf.zeitpunkt), func.sum(Getraenk.preis))
+        .join(Getraenk, Verkauf.getraenk_id == Getraenk.id)
+        .group_by(func.date(Verkauf.zeitpunkt))
+        .order_by(func.date(Verkauf.zeitpunkt))
+        .all()
+    )
+
+    html = render_template("umsatzverlauf_pdf.html", daten=daten)
+    pdf_puffer = io.BytesIO()
+    pisa_status = pisa.CreatePDF(src=html, dest=pdf_puffer)
+    if pisa_status.err:
+        return f"Fehler beim Erstellen des PDFs: {pisa_status.err}"
+
+    response = make_response(pdf_puffer.getvalue())
+    response.headers['Content-Type'] = 'application/pdf'
+    response.headers['Content-Disposition'] = 'inline; filename=umsatzverlauf.pdf'
+    return response
 from flask import make_response, render_template, request, redirect, url_for
 import io
 from xhtml2pdf import pisa
@@ -955,6 +1098,57 @@ def endabrechnung_event():
         }
 
     return render_template("endabrechnung_event.html", events=events, selected_event_id=selected_event_id, daten=daten)
+
+@app.route("/auswertung/endabrechnung_event/export_csv")
+def export_endabrechnung_event_csv():
+    event_id = request.args.get("event_id", type=int)
+    if not event_id:
+        return redirect(url_for("endabrechnung_event"))
+
+    event = Event.query.get_or_404(event_id)
+
+    umsatz = (
+        db.session.query(func.sum(Getraenk.preis))
+        .join(Verkauf, Verkauf.getraenk_id == Getraenk.id)
+        .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+        .filter(TeilnehmerEvent.event_id == event_id)
+        .scalar() or 0.0
+    )
+
+    einnahmen = (
+        db.session.query(func.sum(Einnahme.betrag))
+        .filter(Einnahme.event_id == event_id)
+        .scalar() or 0.0
+    )
+
+    ausgaben = (
+        db.session.query(Ausgabe.kategorie, Ausgabe.beschreibung, Ausgabe.betrag)
+        .filter(Ausgabe.event_id == event_id)
+        .order_by(Ausgabe.datum)
+        .all()
+    )
+    summe_ausgaben = sum(a[2] for a in ausgaben)
+    gewinn = einnahmen + umsatz - summe_ausgaben
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Event", event.name])
+    writer.writerow(["Datum", event.datum.strftime('%Y-%m-%d')])
+    writer.writerow(["Getränkeumsatz", f"{umsatz:.2f}"])
+    writer.writerow(["Gesamteinnahmen", f"{(einnahmen + umsatz):.2f}"])
+    writer.writerow([])
+    writer.writerow(["Kategorie", "Beschreibung", "Betrag"])
+    for k, b, betrag in ausgaben:
+        writer.writerow([k, b, f"{betrag:.2f}"])
+    writer.writerow(["Summe Ausgaben", "", f"{summe_ausgaben:.2f}"])
+    writer.writerow(["Gewinn", "", f"{gewinn:.2f}"])
+
+    output.seek(0)
+    return Response(
+        output,
+        mimetype="text/csv",
+        headers={"Content-Disposition": f"attachment; filename=endabrechnung_event_{event_id}.csv"}
+    )
 @app.route("/auswertung/endabrechnung_jahr")
 def endabrechnung_jahr():
     # Alle Jahre mit Verkäufen
@@ -1012,6 +1206,56 @@ def endabrechnung_jahr():
         })
 
     return render_template("endabrechnung_jahr.html", daten=daten)
+
+@app.route("/auswertung/endabrechnung_jahr/export_csv")
+def export_endabrechnung_jahr_csv():
+    jahre = (
+        db.session.query(func.strftime('%Y', Event.datum))
+        .group_by(func.strftime('%Y', Event.datum))
+        .order_by(func.strftime('%Y', Event.datum))
+        .all()
+    )
+
+    daten = []
+    for jahr_tuple in jahre:
+        jahr = jahr_tuple[0]
+        event_ids = [e.id for e in Event.query.filter(func.strftime('%Y', Event.datum) == jahr).all()]
+
+        umsatz = (
+            db.session.query(func.sum(Getraenk.preis))
+            .join(Verkauf, Verkauf.getraenk_id == Getraenk.id)
+            .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .filter(TeilnehmerEvent.event_id.in_(event_ids))
+            .scalar() or 0.0
+        )
+
+        einnahmen = (
+            db.session.query(func.sum(Einnahme.betrag))
+            .filter(Einnahme.event_id.in_(event_ids))
+            .scalar() or 0.0
+        )
+
+        ausgaben = (
+            db.session.query(func.sum(Ausgabe.betrag))
+            .filter(Ausgabe.event_id.in_(event_ids))
+            .scalar() or 0.0
+        )
+
+        gewinn = einnahmen + umsatz - ausgaben
+        daten.append((jahr, umsatz, einnahmen, ausgaben, gewinn))
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Jahr", "Umsatz", "Einnahmen", "Ausgaben", "Gewinn"])
+    for row in daten:
+        writer.writerow([row[0], f"{row[1]:.2f}", f"{row[2]:.2f}", f"{row[3]:.2f}", f"{row[4]:.2f}"])
+
+    output.seek(0)
+    return Response(
+        output,
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=endabrechnung_jahr.csv"}
+    )
 @app.route("/export/endabrechnung_event/pdf")
 def export_endabrechnung_event_pdf():
     event_id = request.args.get("event_id", type=int)
@@ -1203,3 +1447,82 @@ def verkauf(teilnehmer_event_id):
     )
 
     return render_template("verkauf_form.html", eintrag=eintrag, getraenke=getraenke, verkaufe=verkaufe)
+
+@app.route("/auswertung/eventvergleich")
+def eventvergleich():
+    events = Event.query.order_by(Event.datum).all()
+    daten = []
+    for ev in events:
+        teilnehmer_count = TeilnehmerEvent.query.filter_by(event_id=ev.id).count()
+        umsatz = (
+            db.session.query(func.sum(Verkauf.menge * Getraenk.preis))
+            .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .join(Getraenk, Verkauf.getraenk_id == Getraenk.id)
+            .filter(TeilnehmerEvent.event_id == ev.id)
+            .scalar() or 0.0
+        )
+        daten.append({"event": ev, "teilnehmer": teilnehmer_count, "umsatz": umsatz})
+    return render_template("eventvergleich.html", daten=daten)
+
+@app.route("/auswertung/jahresvergleich")
+def jahresvergleich():
+    jahre = (
+        db.session.query(func.strftime('%Y', Event.datum).label('jahr'))
+        .group_by('jahr')
+        .order_by('jahr')
+        .all()
+    )
+    daten = []
+    for (jahr,) in jahre:
+        events = Event.query.filter(func.strftime('%Y', Event.datum) == jahr).all()
+        event_ids = [e.id for e in events]
+        umsatz = (
+            db.session.query(func.sum(Verkauf.menge * Getraenk.preis))
+            .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .join(Getraenk, Verkauf.getraenk_id == Getraenk.id)
+            .filter(TeilnehmerEvent.event_id.in_(event_ids))
+            .scalar() or 0.0
+        )
+        teilnehmer = (
+            db.session.query(TeilnehmerEvent.id)
+            .filter(TeilnehmerEvent.event_id.in_(event_ids))
+            .count()
+        )
+        daten.append({"jahr": jahr, "events": len(events), "teilnehmer": teilnehmer, "umsatz": umsatz})
+    return render_template("jahresvergleich.html", daten=daten)
+
+@app.route("/auswertung/umsatz_getraenk")
+def umsatz_getraenk():
+    daten = (
+        db.session.query(Getraenk.name, func.count(Verkauf.id), func.sum(Verkauf.menge * Getraenk.preis))
+        .join(Verkauf, Verkauf.getraenk_id == Getraenk.id)
+        .group_by(Getraenk.id)
+        .order_by(Getraenk.name)
+        .all()
+    )
+    return render_template("umsatz_getraenk.html", daten=daten)
+
+@app.route("/auswertung/finanzuebersicht")
+def finanzuebersicht():
+    events = Event.query.order_by(Event.datum).all()
+    daten = []
+    for ev in events:
+        umsatz = (
+            db.session.query(func.sum(Verkauf.menge * Getraenk.preis))
+            .join(TeilnehmerEvent, Verkauf.teilnehmer_event_id == TeilnehmerEvent.id)
+            .join(Getraenk, Verkauf.getraenk_id == Getraenk.id)
+            .filter(TeilnehmerEvent.event_id == ev.id)
+            .scalar() or 0.0
+        )
+        einnahmen = (
+            db.session.query(func.sum(Einnahme.betrag))
+            .filter(Einnahme.event_id == ev.id)
+            .scalar() or 0.0
+        )
+        ausgaben = (
+            db.session.query(func.sum(Ausgabe.betrag))
+            .filter(Ausgabe.event_id == ev.id)
+            .scalar() or 0.0
+        )
+        daten.append({"event": ev, "umsatz": umsatz, "einnahmen": einnahmen, "ausgaben": ausgaben, "gewinn": einnahmen + umsatz - ausgaben})
+    return render_template("finanzuebersicht.html", daten=daten)

--- a/app/templates/auswertungen_overview.html
+++ b/app/templates/auswertungen_overview.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Auswertungen</title>
+</head>
+<body>
+    <h1>Auswertungen</h1>
+
+    <h2>Teilnehmerbezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('teilnehmer_report') }}">Teilnehmerreport (mehrere Events)</a></li>
+        <li><a href="{{ url_for('verbrauch_pro_teilnehmer') }}">Verbrauch pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('teilnehmerliste') }}">Teilnehmerlisten gesamt</a></li>
+        <li><a href="{{ url_for('teilnehmerliste_pro_event') }}">Teilnehmerlisten pro Event</a></li>
+    </ul>
+
+    <h2>Eventbezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('event_uebersicht') }}">Eventübersicht pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('einzelabrechnung_event') }}">Einzelabrechnung pro Event</a></li>
+        <li><a href="{{ url_for('endabrechnung_event') }}">Endabrechnung pro Event</a></li>
+        <li><a href="{{ url_for('eventvergleich') }}">Eventvergleich</a></li>
+    </ul>
+
+    <h2>Zeit- und Jahresbezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('umsatzverlauf') }}">Umsatzverlauf (Datum)</a></li>
+        <li><a href="{{ url_for('umsatz_pro_jahr') }}">Umsatz pro Jahr</a></li>
+        <li><a href="{{ url_for('endabrechnung_jahr') }}">Endabrechnung pro Jahr</a></li>
+        <li><a href="{{ url_for('jahresvergleich') }}">Jahresvergleich</a></li>
+    </ul>
+
+    <h2>Getränkebezogene Auswertungen</h2>
+    <ul>
+        <li><a href="{{ url_for('getraenkestatistik') }}">Getränkestatistik</a></li>
+        <li><a href="{{ url_for('umsatz_getraenk') }}">Umsatz pro Getränk</a></li>
+    </ul>
+
+    <h2>Finanzübersicht</h2>
+    <ul>
+        <li><a href="{{ url_for('umsatz_pro_teilnehmer') }}">Umsatz pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('finanzuebersicht') }}">Einnahmen/Ausgaben gegenüberstellen</a></li>
+    </ul>
+
+    <br><a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+</body>
+</html>

--- a/app/templates/einzelabrechnung_event.html
+++ b/app/templates/einzelabrechnung_event.html
@@ -5,6 +5,7 @@
     <title>Einzelabrechnung pro Teilnehmer</title>
 </head>
 {% if selected_event_id %}
+    <a href="{{ url_for('export_einzelabrechnung_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
     <a href="{{ url_for('einzelabrechnung_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export</a>
 {% endif %}
 <body>

--- a/app/templates/endabrechnung_event.html
+++ b/app/templates/endabrechnung_event.html
@@ -53,9 +53,8 @@
         <p><strong>{{ "Gewinn" if daten.gewinn >= 0 else "Verlust" }}:</strong> {{ "%.2f"|format(daten.gewinn) }} CHF</p>
 
         <br>
-        <a href="{{ url_for('export_endabrechnung_event_pdf', event_id=selected_event_id) }}" target="_blank">
-            📄 PDF-Export der Endabrechnung
-        </a>
+        <a href="{{ url_for('export_endabrechnung_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_endabrechnung_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export der Endabrechnung</a>
     {% endif %}
 
     <br><br>

--- a/app/templates/endabrechnung_jahr.html
+++ b/app/templates/endabrechnung_jahr.html
@@ -7,9 +7,8 @@
 <body>
     <h1>Endabrechnung pro Jahr</h1>
 
-    <a href="{{ url_for('export_endabrechnung_jahr_pdf') }}" target="_blank">
-        📄 PDF-Export der Jahresendabrechnung
-    </a>
+    <a href="{{ url_for('export_endabrechnung_jahr_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_endabrechnung_jahr_pdf') }}" target="_blank">📄 PDF-Export der Jahresendabrechnung</a>
 
     <br><br>
 

--- a/app/templates/event_uebersicht.html
+++ b/app/templates/event_uebersicht.html
@@ -21,7 +21,8 @@
 
     {% if selected_event_id %}
         <p>
-            📥 <a href="{{ url_for('export_csv', event_id=selected_event_id) }}">Teilnehmer-Export (CSV)</a><br>
+            📥 <a href="{{ url_for('export_csv', event_id=selected_event_id) }}">Teilnehmer-Export (CSV)</a> |
+            📄 <a href="{{ url_for('export_event_uebersicht_pdf', event_id=selected_event_id) }}" target="_blank">PDF</a>
         </p>
     {% endif %}
 

--- a/app/templates/event_uebersicht_pdf.html
+++ b/app/templates/event_uebersicht_pdf.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        h1, h2 { margin-bottom: 0; }
+        table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+        th, td { border: 1px solid #444; padding: 5px; }
+        th { background-color: #eee; }
+        hr { margin: 20px 0; }
+    </style>
+    <title>Eventübersicht</title>
+</head>
+<body>
+    <h1>Eventübersicht – {{ event.name }}</h1>
+    <p>Datum: {{ event.datum.strftime('%d.%m.%Y') }}</p>
+    {% for eintrag in daten %}
+        <h2>{{ eintrag.teilnehmer }} (Status: {{ eintrag.status }})</h2>
+        <table>
+            <tr>
+                <th>Getränk</th>
+                <th>Anzahl</th>
+                <th>Betrag</th>
+            </tr>
+            {% for getraenk, menge, betrag in eintrag.buchungen %}
+            <tr>
+                <td>{{ getraenk }}</td>
+                <td>{{ menge }}</td>
+                <td>{{ "%.2f"|format(betrag or 0) }} CHF</td>
+            </tr>
+            {% endfor %}
+            <tr>
+                <td colspan="2"><strong>Gesamt</strong></td>
+                <td><strong>{{ "%.2f"|format(eintrag.gesamt) }} CHF</strong></td>
+            </tr>
+        </table>
+        <hr>
+    {% endfor %}
+</body>
+</html>

--- a/app/templates/eventvergleich.html
+++ b/app/templates/eventvergleich.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Eventvergleich</title>
+</head>
+<body>
+    <h1>Eventvergleich</h1>
+    <table border="1" cellpadding="6">
+        <tr>
+            <th>Event</th>
+            <th>Teilnehmer</th>
+            <th>Umsatz (CHF)</th>
+        </tr>
+        {% for eintrag in daten %}
+        <tr>
+            <td>{{ eintrag.event.name }}</td>
+            <td>{{ eintrag.teilnehmer }}</td>
+            <td>{{ "%.2f"|format(eintrag.umsatz) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <br>
+    <a href="{{ url_for('auswertungen_overview') }}">Zurück zur Übersicht</a>
+</body>
+</html>

--- a/app/templates/finanzuebersicht.html
+++ b/app/templates/finanzuebersicht.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Finanzübersicht</title>
+</head>
+<body>
+    <h1>Finanzübersicht</h1>
+    <table border="1" cellpadding="6">
+        <tr>
+            <th>Event</th>
+            <th>Umsatz (CHF)</th>
+            <th>Einnahmen (CHF)</th>
+            <th>Ausgaben (CHF)</th>
+            <th>Gewinn (CHF)</th>
+        </tr>
+        {% for e in daten %}
+        <tr>
+            <td>{{ e.event.name }}</td>
+            <td>{{ "%.2f"|format(e.umsatz) }}</td>
+            <td>{{ "%.2f"|format(e.einnahmen) }}</td>
+            <td>{{ "%.2f"|format(e.ausgaben) }}</td>
+            <td>{{ "%.2f"|format(e.gewinn) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <br>
+    <a href="{{ url_for('auswertungen_overview') }}">Zurück zur Übersicht</a>
+</body>
+</html>

--- a/app/templates/getraenkestatistik.html
+++ b/app/templates/getraenkestatistik.html
@@ -22,7 +22,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_getraenkestatistik_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_getraenkestatistik_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_getraenkestatistik_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,7 +37,7 @@
             </a>
 
             <!-- Auswertungen -->
-            <a href="{{ url_for('teilnehmer_report') }}" class="bg-white text-gray-900 rounded-xl p-6 shadow hover:bg-blue-100 transition">
+            <a href="{{ url_for('auswertungen_overview') }}" class="bg-white text-gray-900 rounded-xl p-6 shadow hover:bg-blue-100 transition">
                 <div class="text-xl font-semibold mb-1">📊 Auswertungen</div>
                 <p class="text-sm text-gray-600">Verbrauch & Abrechnung ansehen</p>
             </a>

--- a/app/templates/jahresvergleich.html
+++ b/app/templates/jahresvergleich.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Jahresvergleich</title>
+</head>
+<body>
+    <h1>Jahresvergleich</h1>
+    <table border="1" cellpadding="6">
+        <tr>
+            <th>Jahr</th>
+            <th>Anzahl Events</th>
+            <th>Teilnahmen</th>
+            <th>Umsatz (CHF)</th>
+        </tr>
+        {% for eintrag in daten %}
+        <tr>
+            <td>{{ eintrag.jahr }}</td>
+            <td>{{ eintrag.events }}</td>
+            <td>{{ eintrag.teilnehmer }}</td>
+            <td>{{ "%.2f"|format(eintrag.umsatz) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <br>
+    <a href="{{ url_for('auswertungen_overview') }}">Zurück zur Übersicht</a>
+</body>
+</html>

--- a/app/templates/teilnehmer_report.html
+++ b/app/templates/teilnehmer_report.html
@@ -6,6 +6,10 @@
 </head>
 <body>
     <h1>Teilnehmerauswertung über mehrere Events</h1>
+    <p>
+        <a href="{{ url_for('teilnehmer_report_export') }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('teilnehmer_report_pdf') }}" target="_blank">📄 PDF-Export</a>
+    </p>
 
     {% if daten %}
         {% for eintrag in daten %}

--- a/app/templates/teilnehmerliste.html
+++ b/app/templates/teilnehmerliste.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_teilnehmerliste_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_teilnehmerliste_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_teilnehmerliste_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/teilnehmerliste_event.html
+++ b/app/templates/teilnehmerliste_event.html
@@ -32,7 +32,8 @@
             {% endfor %}
         </table>
         <br>
-        <a href="{{ url_for('export_teilnehmerliste_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a>
+        <a href="{{ url_for('export_teilnehmerliste_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_teilnehmerliste_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export</a>
     {% endif %}
 
     <br><br>

--- a/app/templates/umsatz_getraenk.html
+++ b/app/templates/umsatz_getraenk.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Umsatz pro Getränk</title>
+</head>
+<body>
+    <h1>Umsatz pro Getränk</h1>
+    <table border="1" cellpadding="6">
+        <tr>
+            <th>Getränk</th>
+            <th>Anzahl</th>
+            <th>Umsatz (CHF)</th>
+        </tr>
+        {% for name, menge, betrag in daten %}
+        <tr>
+            <td>{{ name }}</td>
+            <td>{{ menge }}</td>
+            <td>{{ "%.2f"|format(betrag) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <br>
+    <a href="{{ url_for('auswertungen_overview') }}">Zurück zur Übersicht</a>
+</body>
+</html>

--- a/app/templates/umsatz_jahr.html
+++ b/app/templates/umsatz_jahr.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_umsatz_pro_jahr_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_umsatz_pro_jahr_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_umsatz_pro_jahr_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/umsatz_teilnehmer.html
+++ b/app/templates/umsatz_teilnehmer.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_umsatz_pro_teilnehmer_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_umsatz_pro_teilnehmer_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_umsatz_pro_teilnehmer_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/umsatzverlauf.html
+++ b/app/templates/umsatzverlauf.html
@@ -20,7 +20,8 @@
     </table>
 
     <br>
-    <a href="{{ url_for('export_umsatzverlauf_csv') }}">📥 CSV-Export</a>
+    <a href="{{ url_for('export_umsatzverlauf_csv') }}">📥 CSV-Export</a> |
+    <a href="{{ url_for('export_umsatzverlauf_pdf') }}" target="_blank">📄 PDF-Export</a>
     <br><br>
     <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
 </body>

--- a/app/templates/umsatzverlauf_pdf.html
+++ b/app/templates/umsatzverlauf_pdf.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+        th, td { border: 1px solid #444; padding: 5px; }
+        th { background-color: #eee; }
+    </style>
+    <title>Umsatzverlauf</title>
+</head>
+<body>
+    <h1>Umsatzverlauf (täglich)</h1>
+    <table>
+        <tr><th>Datum</th><th>Umsatz (CHF)</th></tr>
+        {% for datum, betrag in daten %}
+        <tr><td>{{ datum }}</td><td>{{ "%.2f"|format(betrag or 0) }}</td></tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/app/templates/verbrauch_teilnehmer.html
+++ b/app/templates/verbrauch_teilnehmer.html
@@ -6,6 +6,10 @@
 </head>
 <body>
     <h1>Verbrauch pro Teilnehmer</h1>
+    <p>
+        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_csv') }}">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_pdf') }}" target="_blank">📄 PDF-Export</a>
+    </p>
 
     {% for eintrag in daten %}
         <h2>{{ eintrag.teilnehmer }}</h2>


### PR DESCRIPTION
## Summary
- include new analyses in the overview list
- implement event and year comparisons
- add reports for beverage sales and finance overview

## Testing
- `python -m py_compile app/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68586e9bf4948327ba660ae6cdb6026f