### PR TITLE
Styling for reports

### DIFF
--- a/app/templates/auswertungen_overview.html
+++ b/app/templates/auswertungen_overview.html
@@ -3,53 +3,53 @@
 <head>
     <meta charset="UTF-8">
     <title>Auswertungen</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Auswertungen</h1>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <h2>Teilnehmerbezogene Auswertungen</h2>
-    <ul>
-        <li><a href="{{ url_for('teilnehmer_report') }}">Teilnehmerreport (mehrere Events)</a></li>
-        <li><a href="{{ url_for('verbrauch_pro_teilnehmer') }}">Verbrauch pro Teilnehmer</a></li>
-        <li><a href="{{ url_for('teilnehmerliste') }}">Teilnehmerlisten gesamt</a></li>
-        <li><a href="{{ url_for('teilnehmerliste_pro_event') }}">Teilnehmerlisten pro Event</a></li>
-        <li><a href="{{ url_for('teilnehmer_report') }}">Teilnehmerreport</a></li>
-        <li><a href="{{ url_for('verbrauch_pro_teilnehmer') }}">Verbrauch pro Teilnehmer</a></li>
-        <li><a href="{{ url_for('teilnehmerliste') }}">Teilnehmerliste</a></li>
-        <li><a href="{{ url_for('teilnehmerliste_pro_event') }}">Teilnehmerliste pro Event</a></li>
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">📊 Auswertungen</h1>
+
+    <h2 class="text-xl font-semibold mt-6">Teilnehmerbezogene Auswertungen</h2>
+    <ul class="list-disc list-inside space-y-1">
+        <li><a href="{{ url_for('teilnehmer_report') }}" class="text-blue-400 hover:underline">Teilnehmerreport (mehrere Events)</a></li>
+        <li><a href="{{ url_for('verbrauch_pro_teilnehmer') }}" class="text-blue-400 hover:underline">Verbrauch pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('teilnehmerliste') }}" class="text-blue-400 hover:underline">Teilnehmerlisten gesamt</a></li>
+        <li><a href="{{ url_for('teilnehmerliste_pro_event') }}" class="text-blue-400 hover:underline">Teilnehmerlisten pro Event</a></li>
     </ul>
 
-    <h2>Eventbezogene Auswertungen</h2>
-    <ul>
-        <li><a href="{{ url_for('event_uebersicht') }}">Eventübersicht pro Teilnehmer</a></li>
-        <li><a href="{{ url_for('einzelabrechnung_event') }}">Einzelabrechnung pro Event</a></li>
-        <li><a href="{{ url_for('endabrechnung_event') }}">Endabrechnung pro Event</a></li>
-        <li><a href="{{ url_for('eventvergleich') }}">Eventvergleich</a></li>
+    <h2 class="text-xl font-semibold mt-6">Eventbezogene Auswertungen</h2>
+    <ul class="list-disc list-inside space-y-1">
+        <li><a href="{{ url_for('event_uebersicht') }}" class="text-blue-400 hover:underline">Eventübersicht pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('einzelabrechnung_event') }}" class="text-blue-400 hover:underline">Einzelabrechnung pro Event</a></li>
+        <li><a href="{{ url_for('endabrechnung_event') }}" class="text-blue-400 hover:underline">Endabrechnung pro Event</a></li>
+        <li><a href="{{ url_for('eventvergleich') }}" class="text-blue-400 hover:underline">Eventvergleich</a></li>
     </ul>
 
-    <h2>Zeit- und Jahresbezogene Auswertungen</h2>
-    <ul>
-        <li><a href="{{ url_for('umsatzverlauf') }}">Umsatzverlauf (Datum)</a></li>
-        <li><a href="{{ url_for('umsatz_pro_jahr') }}">Umsatz pro Jahr</a></li>
-        <li><a href="{{ url_for('endabrechnung_jahr') }}">Endabrechnung pro Jahr</a></li>
-        <li><a href="{{ url_for('jahresvergleich') }}">Jahresvergleich</a></li>
-        <li><a href="{{ url_for('umsatzverlauf') }}">Umsatzverlauf</a></li>
-        <li><a href="{{ url_for('umsatz_pro_jahr') }}">Umsatz pro Jahr</a></li>
-        <li><a href="{{ url_for('endabrechnung_jahr') }}">Endabrechnung pro Jahr</a></li>
+    <h2 class="text-xl font-semibold mt-6">Zeit- und Jahresbezogene Auswertungen</h2>
+    <ul class="list-disc list-inside space-y-1">
+        <li><a href="{{ url_for('umsatzverlauf') }}" class="text-blue-400 hover:underline">Umsatzverlauf (Datum)</a></li>
+        <li><a href="{{ url_for('umsatz_pro_jahr') }}" class="text-blue-400 hover:underline">Umsatz pro Jahr</a></li>
+        <li><a href="{{ url_for('endabrechnung_jahr') }}" class="text-blue-400 hover:underline">Endabrechnung pro Jahr</a></li>
+        <li><a href="{{ url_for('jahresvergleich') }}" class="text-blue-400 hover:underline">Jahresvergleich</a></li>
     </ul>
 
-    <h2>Getränkebezogene Auswertungen</h2>
-    <ul>
-        <li><a href="{{ url_for('getraenkestatistik') }}">Getränkestatistik</a></li>
-        <li><a href="{{ url_for('umsatz_getraenk') }}">Umsatz pro Getränk</a></li>
+    <h2 class="text-xl font-semibold mt-6">Getränkebezogene Auswertungen</h2>
+    <ul class="list-disc list-inside space-y-1">
+        <li><a href="{{ url_for('getraenkestatistik') }}" class="text-blue-400 hover:underline">Getränkestatistik</a></li>
+        <li><a href="{{ url_for('umsatz_getraenk') }}" class="text-blue-400 hover:underline">Umsatz pro Getränk</a></li>
     </ul>
 
-    <h2>Finanzübersicht</h2>
-    <ul>
-        <li><a href="{{ url_for('umsatz_pro_teilnehmer') }}">Umsatz pro Teilnehmer</a></li>
-        <li><a href="{{ url_for('finanzuebersicht') }}">Einnahmen/Ausgaben gegenüberstellen</a></li>
+    <h2 class="text-xl font-semibold mt-6">Finanzübersicht</h2>
+    <ul class="list-disc list-inside space-y-1">
+        <li><a href="{{ url_for('umsatz_pro_teilnehmer') }}" class="text-blue-400 hover:underline">Umsatz pro Teilnehmer</a></li>
+        <li><a href="{{ url_for('finanzuebersicht') }}" class="text-blue-400 hover:underline">Einnahmen/Ausgaben gegenüberstellen</a></li>
     </ul>
 
-    <br><a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/finanzuebersicht.html
+++ b/app/templates/finanzuebersicht.html
@@ -3,28 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <title>Finanzübersicht</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Finanzübersicht</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Event</th>
-            <th>Umsatz (CHF)</th>
-            <th>Einnahmen (CHF)</th>
-            <th>Ausgaben (CHF)</th>
-            <th>Gewinn (CHF)</th>
-        </tr>
-        {% for e in daten %}
-        <tr>
-            <td>{{ e.event.name }}</td>
-            <td>{{ "%.2f"|format(e.umsatz) }}</td>
-            <td>{{ "%.2f"|format(e.einnahmen) }}</td>
-            <td>{{ "%.2f"|format(e.ausgaben) }}</td>
-            <td>{{ "%.2f"|format(e.gewinn) }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-    <br>
-    <a href="{{ url_for('auswertungen_overview') }}">Zurück zur Übersicht</a>
+<body class="bg-gray-900 text-white min-h-screen">
+
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">💶 Finanzübersicht</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Event</th>
+                    <th class="px-4 py-2 text-right">Umsatz (CHF)</th>
+                    <th class="px-4 py-2 text-right">Einnahmen (CHF)</th>
+                    <th class="px-4 py-2 text-right">Ausgaben (CHF)</th>
+                    <th class="px-4 py-2 text-right">Gewinn (CHF)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for e in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ e.event.name }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(e.umsatz) }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(e.einnahmen) }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(e.ausgaben) }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(e.gewinn) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('auswertungen_overview') }}" class="text-blue-400 hover:underline">Zurück zur Übersicht</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/getraenkestatistik.html
+++ b/app/templates/getraenkestatistik.html
@@ -3,28 +3,44 @@
 <head>
     <meta charset="UTF-8">
     <title>Getränkestatistik</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Getränkestatistik (gesamt)</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Getränk</th>
-            <th>Anzahl</th>
-            <th>Umsatz (CHF)</th>
-        </tr>
-        {% for name, anzahl, betrag in daten %}
-        <tr>
-            <td>{{ name }}</td>
-            <td>{{ anzahl }}</td>
-            <td>{{ "%.2f"|format(betrag) }}</td>
-        </tr>
-        {% endfor %}
-    </table>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <br>
-    <a href="{{ url_for('export_getraenkestatistik_csv') }}">📥 CSV-Export</a> |
-    <a href="{{ url_for('export_getraenkestatistik_pdf') }}" target="_blank">📄 PDF-Export</a>
-    <br><br>
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">📊 Getränkestatistik (gesamt)</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Getränk</th>
+                    <th class="px-4 py-2 text-right">Anzahl</th>
+                    <th class="px-4 py-2 text-right">Umsatz (CHF)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, anzahl, betrag in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ name }}</td>
+                    <td class="px-4 py-1 text-right">{{ anzahl }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-6 text-sm">
+        <a href="{{ url_for('export_getraenkestatistik_csv') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a>
+        |
+        <a href="{{ url_for('export_getraenkestatistik_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/teilnehmer_report.html
+++ b/app/templates/teilnehmer_report.html
@@ -3,32 +3,58 @@
 <head>
     <meta charset="UTF-8">
     <title>Teilnehmerreport</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Teilnehmerauswertung über mehrere Events</h1>
-    <p>
-        <a href="{{ url_for('teilnehmer_report_export') }}">📥 CSV-Export</a> |
-        <a href="{{ url_for('teilnehmer_report_pdf') }}" target="_blank">📄 PDF-Export</a>
-    </p>
+<body class="bg-gray-900 text-white min-h-screen">
+
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">📄 Teilnehmerauswertung über mehrere Events</h1>
+
+    <div class="text-sm mb-6">
+        <a href="{{ url_for('teilnehmer_report_export') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a> |
+        <a href="{{ url_for('teilnehmer_report_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
 
     {% if daten %}
         {% for eintrag in daten %}
-            <h3>{{ eintrag.teilnehmer }}</h3>
-            {% if eintrag.events %}
-                <ul>
-                {% for e in eintrag.events %}
-                    <li>{{ e[0] }} – {{ e[1] }} Getränke – {{ "%.2f"|format(e[2]) }} CHF</li>
-                {% endfor %}
-                </ul>
-                <strong>Gesamtsumme: {{ "%.2f"|format(eintrag.gesamt) }} CHF</strong>
-            {% else %}
-                <p><em>Keine Buchungen</em></p>
-            {% endif %}
+            <div class="bg-gray-800 p-4 rounded shadow mb-6">
+                <h2 class="text-xl font-semibold mb-2">{{ eintrag.teilnehmer }}</h2>
+                {% if eintrag.events %}
+                    <table class="w-full table-auto mb-2">
+                        <thead>
+                            <tr class="bg-gray-700">
+                                <th class="px-4 py-2 text-left">Event</th>
+                                <th class="px-4 py-2 text-right">Getränke</th>
+                                <th class="px-4 py-2 text-right">Betrag (CHF)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for e in eintrag.events %}
+                            <tr class="border-b border-gray-600">
+                                <td class="px-4 py-1">{{ e[0] }}</td>
+                                <td class="px-4 py-1 text-right">{{ e[1] }}</td>
+                                <td class="px-4 py-1 text-right">{{ "%.2f"|format(e[2]) }}</td>
+                            </tr>
+                            {% endfor %}
+                            <tr class="font-bold bg-gray-700">
+                                <td class="px-4 py-2 text-right" colspan="2">Gesamtsumme:</td>
+                                <td class="px-4 py-2 text-right">{{ "%.2f"|format(eintrag.gesamt) }} CHF</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                {% else %}
+                    <p class="text-gray-400">Keine Buchungen</p>
+                {% endif %}
+            </div>
         {% endfor %}
     {% else %}
-        <p>Keine Teilnehmerdaten vorhanden.</p>
+        <p class="text-center text-gray-400">Keine Teilnehmerdaten vorhanden.</p>
     {% endif %}
 
-    <br><a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/teilnehmerliste.html
+++ b/app/templates/teilnehmerliste.html
@@ -3,26 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <title>Teilnehmerliste</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Teilnehmerliste</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Name</th>
-            <th>Anzahl Teilnahmen</th>
-        </tr>
-        {% for name, teilnahmen in daten %}
-        <tr>
-            <td>{{ name }}</td>
-            <td>{{ teilnahmen }}</td>
-        </tr>
-        {% endfor %}
-    </table>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <br>
-    <a href="{{ url_for('export_teilnehmerliste_csv') }}">📥 CSV-Export</a> |
-    <a href="{{ url_for('export_teilnehmerliste_pdf') }}" target="_blank">📄 PDF-Export</a>
-    <br><br>
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">👥 Teilnehmerliste</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Name</th>
+                    <th class="px-4 py-2 text-right">Anzahl Teilnahmen</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, teilnahmen in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ name }}</td>
+                    <td class="px-4 py-1 text-right">{{ teilnahmen }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-6 text-sm">
+        <a href="{{ url_for('export_teilnehmerliste_csv') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a>
+        |
+        <a href="{{ url_for('export_teilnehmerliste_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/teilnehmerliste_event.html
+++ b/app/templates/teilnehmerliste_event.html
@@ -3,13 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <title>Teilnehmer pro Event</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Teilnehmerliste pro Event</h1>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <form method="get" action="{{ url_for('teilnehmerliste_pro_event') }}">
-        <label for="event">Event auswählen:</label>
-        <select name="event_id" id="event" onchange="this.form.submit()">
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">👥 Teilnehmerliste pro Event</h1>
+
+    <form method="get" action="{{ url_for('teilnehmerliste_pro_event') }}" class="mb-6 text-center">
+        <label for="event" class="mr-2">Event auswählen:</label>
+        <select name="event_id" id="event" onchange="this.form.submit()" class="text-black px-3 py-1 rounded">
             <option value="">-- bitte wählen --</option>
             {% for event in events %}
                 <option value="{{ event.id }}" {% if selected_event_id == event.id %}selected{% endif %}>{{ event.name }}</option>
@@ -18,25 +21,36 @@
     </form>
 
     {% if daten %}
-        <h2>Teilnehmer</h2>
-        <table border="1" cellpadding="6">
-            <tr>
-                <th>Name</th>
-                <th>Bezahlstatus</th>
-            </tr>
-            {% for name, status in daten %}
-            <tr>
-                <td>{{ name }}</td>
-                <td>{{ status }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-        <br>
-        <a href="{{ url_for('export_teilnehmerliste_event_csv', event_id=selected_event_id) }}">📥 CSV-Export</a> |
-        <a href="{{ url_for('export_teilnehmerliste_event_pdf', event_id=selected_event_id) }}" target="_blank">📄 PDF-Export</a>
+        <div class="bg-gray-800 p-4 rounded shadow-md">
+            <table class="w-full table-auto">
+                <thead>
+                    <tr class="bg-gray-700">
+                        <th class="px-4 py-2 text-left">Name</th>
+                        <th class="px-4 py-2 text-left">Bezahlstatus</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for name, status in daten %}
+                    <tr class="border-b border-gray-600">
+                        <td class="px-4 py-1">{{ name }}</td>
+                        <td class="px-4 py-1">{{ status }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        <div class="mt-6 text-sm">
+            <a href="{{ url_for('export_teilnehmerliste_event_csv', event_id=selected_event_id) }}" class="text-blue-400 hover:underline">📥 CSV-Export</a>
+            |
+            <a href="{{ url_for('export_teilnehmerliste_event_pdf', event_id=selected_event_id) }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+        </div>
     {% endif %}
 
-    <br><br>
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/umsatz_getraenk.html
+++ b/app/templates/umsatz_getraenk.html
@@ -3,24 +3,38 @@
 <head>
     <meta charset="UTF-8">
     <title>Umsatz pro Getränk</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Umsatz pro Getränk</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Getränk</th>
-            <th>Anzahl</th>
-            <th>Umsatz (CHF)</th>
-        </tr>
-        {% for name, menge, betrag in daten %}
-        <tr>
-            <td>{{ name }}</td>
-            <td>{{ menge }}</td>
-            <td>{{ "%.2f"|format(betrag) }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-    <br>
-    <a href="{{ url_for('auswertungen_overview') }}">Zurück zur Übersicht</a>
+<body class="bg-gray-900 text-white min-h-screen">
+
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">🥤 Umsatz pro Getränk</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Getränk</th>
+                    <th class="px-4 py-2 text-right">Anzahl</th>
+                    <th class="px-4 py-2 text-right">Umsatz (CHF)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, menge, betrag in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ name }}</td>
+                    <td class="px-4 py-1 text-right">{{ menge }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('auswertungen_overview') }}" class="text-blue-400 hover:underline">Zurück zur Übersicht</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/umsatz_jahr.html
+++ b/app/templates/umsatz_jahr.html
@@ -3,26 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <title>Umsatz pro Jahr</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Umsatzübersicht pro Jahr</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Jahr</th>
-            <th>Umsatz (CHF)</th>
-        </tr>
-        {% for jahr, betrag in daten %}
-        <tr>
-            <td>{{ jahr }}</td>
-            <td>{{ "%.2f"|format(betrag) }}</td>
-        </tr>
-        {% endfor %}
-    </table>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <br>
-    <a href="{{ url_for('export_umsatz_pro_jahr_csv') }}">📥 CSV-Export</a> |
-    <a href="{{ url_for('export_umsatz_pro_jahr_pdf') }}" target="_blank">📄 PDF-Export</a>
-    <br><br>
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">📅 Umsatzübersicht pro Jahr</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Jahr</th>
+                    <th class="px-4 py-2 text-right">Umsatz (CHF)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for jahr, betrag in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ jahr }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-6 text-sm">
+        <a href="{{ url_for('export_umsatz_pro_jahr_csv') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a>
+        |
+        <a href="{{ url_for('export_umsatz_pro_jahr_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/umsatz_teilnehmer.html
+++ b/app/templates/umsatz_teilnehmer.html
@@ -3,26 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <title>Umsatz pro Teilnehmer</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Umsatzübersicht pro Teilnehmer</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Teilnehmer</th>
-            <th>Umsatz (CHF)</th>
-        </tr>
-        {% for name, betrag in daten %}
-        <tr>
-            <td>{{ name }}</td>
-            <td>{{ "%.2f"|format(betrag) }}</td>
-        </tr>
-        {% endfor %}
-    </table>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <br>
-    <a href="{{ url_for('export_umsatz_pro_teilnehmer_csv') }}">📥 CSV-Export</a> |
-    <a href="{{ url_for('export_umsatz_pro_teilnehmer_pdf') }}" target="_blank">📄 PDF-Export</a>
-    <br><br>
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">💰 Umsatzübersicht pro Teilnehmer</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Teilnehmer</th>
+                    <th class="px-4 py-2 text-right">Umsatz (CHF)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, betrag in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ name }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-6 text-sm">
+        <a href="{{ url_for('export_umsatz_pro_teilnehmer_csv') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a>
+        |
+        <a href="{{ url_for('export_umsatz_pro_teilnehmer_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/umsatzverlauf.html
+++ b/app/templates/umsatzverlauf.html
@@ -3,26 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <title>Umsatzverlauf nach Datum</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Umsatzverlauf (täglich)</h1>
-    <table border="1" cellpadding="6">
-        <tr>
-            <th>Datum</th>
-            <th>Umsatz (CHF)</th>
-        </tr>
-        {% for datum, betrag in daten %}
-        <tr>
-            <td>{{ datum }}</td>
-            <td>{{ "%.2f"|format(betrag) }}</td>
-        </tr>
-        {% endfor %}
-    </table>
+<body class="bg-gray-900 text-white min-h-screen">
 
-    <br>
-    <a href="{{ url_for('export_umsatzverlauf_csv') }}">📥 CSV-Export</a> |
-    <a href="{{ url_for('export_umsatzverlauf_pdf') }}" target="_blank">📄 PDF-Export</a>
-    <br><br>
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">📈 Umsatzverlauf (täglich)</h1>
+
+    <div class="bg-gray-800 p-4 rounded shadow-md">
+        <table class="w-full table-auto">
+            <thead>
+                <tr class="bg-gray-700">
+                    <th class="px-4 py-2 text-left">Datum</th>
+                    <th class="px-4 py-2 text-right">Umsatz (CHF)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for datum, betrag in daten %}
+                <tr class="border-b border-gray-600">
+                    <td class="px-4 py-1">{{ datum }}</td>
+                    <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-6 text-sm">
+        <a href="{{ url_for('export_umsatzverlauf_csv') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a>
+        |
+        <a href="{{ url_for('export_umsatzverlauf_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
+
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>

--- a/app/templates/verbrauch_teilnehmer.html
+++ b/app/templates/verbrauch_teilnehmer.html
@@ -3,35 +3,65 @@
 <head>
     <meta charset="UTF-8">
     <title>Verbrauch pro Teilnehmer</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Verbrauch pro Teilnehmer</h1>
-    <p>
-        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_csv') }}">📥 CSV-Export</a> |
-        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_pdf') }}" target="_blank">📄 PDF-Export</a>
-    </p>
+<body class="bg-gray-900 text-white min-h-screen">
+
+<div class="max-w-4xl mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold text-center mb-8">🧾 Verbrauch pro Teilnehmer</h1>
+
+    <div class="text-sm mb-6">
+        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_csv') }}" class="text-blue-400 hover:underline">📥 CSV-Export</a> |
+        <a href="{{ url_for('export_verbrauch_pro_teilnehmer_pdf') }}" target="_blank" class="text-blue-400 hover:underline">📄 PDF-Export</a>
+    </div>
 
     {% for eintrag in daten %}
-        <h2>{{ eintrag.teilnehmer }}</h2>
-        <p><strong>Gesamtumsatz:</strong> {{ "%.2f"|format(eintrag.gesamt) }} CHF</p>
+        <div class="bg-gray-800 p-4 rounded shadow mb-6">
+            <h2 class="text-xl font-semibold mb-2">{{ eintrag.teilnehmer }}</h2>
+            <p class="mb-3"><strong>Gesamtumsatz:</strong> {{ "%.2f"|format(eintrag.gesamt) }} CHF</p>
 
-        <h3>Nach Jahr</h3>
-        <ul>
-            {% for jahr, betrag in eintrag.jahre %}
-                <li>{{ jahr }}: {{ "%.2f"|format(betrag) }} CHF</li>
-            {% endfor %}
-        </ul>
+            <h3 class="font-semibold mt-4 mb-1">Nach Jahr</h3>
+            <table class="w-full table-auto mb-4">
+                <thead>
+                    <tr class="bg-gray-700">
+                        <th class="px-4 py-2 text-left">Jahr</th>
+                        <th class="px-4 py-2 text-right">Betrag (CHF)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for jahr, betrag in eintrag.jahre %}
+                    <tr class="border-b border-gray-600">
+                        <td class="px-4 py-1">{{ jahr }}</td>
+                        <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
 
-        <h3>Nach Event</h3>
-        <ul>
-            {% for eventname, betrag in eintrag.events %}
-                <li>{{ eventname }}: {{ "%.2f"|format(betrag) }} CHF</li>
-            {% endfor %}
-        </ul>
-
-        <hr>
+            <h3 class="font-semibold mt-4 mb-1">Nach Event</h3>
+            <table class="w-full table-auto">
+                <thead>
+                    <tr class="bg-gray-700">
+                        <th class="px-4 py-2 text-left">Event</th>
+                        <th class="px-4 py-2 text-right">Betrag (CHF)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for eventname, betrag in eintrag.events %}
+                    <tr class="border-b border-gray-600">
+                        <td class="px-4 py-1">{{ eventname }}</td>
+                        <td class="px-4 py-1 text-right">{{ "%.2f"|format(betrag) }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% endfor %}
 
-    <a href="{{ url_for('index') }}">Zurück zur Startseite</a>
+    <div class="text-center mt-10">
+        <a href="{{ url_for('index') }}" class="text-blue-400 hover:underline">Zurück zur Startseite</a>
+    </div>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle `auswertungen_overview` page with Tailwind
- apply consistent dark layout to report pages
- show tables styled like the sales view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858827cace08327aca273774c69ce4e